### PR TITLE
Add the possibility to cancel a game

### DIFF
--- a/src/client/GameClient.js
+++ b/src/client/GameClient.js
@@ -35,6 +35,10 @@ export default class GameClient extends Client {
     return this._server.requestAuthorized(this.name, 'createGame', [gameOptions])
   }
 
+  cancelGame(gameId) {
+    return this._server.requestAuthorized(this.name, 'cancelGame', [gameId])
+  }
+
   joinGame(gameId, options) {
     let args = [gameId];
     if (options) args.push(options);

--- a/src/game-app.js
+++ b/src/game-app.js
@@ -595,6 +595,7 @@ function renderMessage(message) {
 
 async function showPublicIntro(gameData) {
   renderShareLink(gameData.id, document.querySelector('#public .shareLink'));
+  renderCancelButton(gameData.id, document.querySelector('#public .cancelButton'));
 
   let $greeting = $('#public .greeting');
   let myTeam = gameData.state.teams.find(t => t && t.playerId === authClient.playerId);
@@ -612,6 +613,7 @@ async function showPublicIntro(gameData) {
 }
 async function showPrivateIntro(gameData) {
   renderShareLink(gameData.id, document.querySelector('#private .shareLink'));
+  renderCancelButton(gameData.id, document.querySelector('#private .cancelButton'));
 
   let $greeting = $('#private .greeting');
   let myTeam = gameData.state.teams.find(t => t && t.playerId === authClient.playerId);
@@ -627,6 +629,34 @@ async function showPrivateIntro(gameData) {
 
   return loadGame(transport);
 }
+
+function renderCancelButton(gameId, container) {
+  let cancelButton = '<SPAN class="cancel"><SPAN class="fa fa-trash"></SPAN><SPAN class="label">Cancel Game</SPAN></SPAN>';
+  container.innerHTML = cancelButton;
+  container.addEventListener('click', event => {
+    popup({
+      title: "Cancel the game?",
+      message: 'Please confirm that you want to cancel this game',
+      buttons: [
+        {
+          label:'Yes',
+          onClick: () => {
+            gameClient.cancelGame(gameId)
+              .then(() => {
+                location.href = '/online.html';
+              });
+          }
+        },
+        {
+          label: 'No'
+        },
+      ],
+      minWidth: '250px',
+      zIndex: 10,
+    });
+  })
+}
+
 function renderShareLink(gameId, container) {
   let link = location.origin + '/game.html?' + gameId;
 

--- a/static/game.html
+++ b/static/game.html
@@ -62,7 +62,8 @@
     .intro .content > DIV {
       padding: 8px;
     }
-    .intro .content .shareLink {
+    .intro .content .shareLink,
+    .cancelButton {
       text-align: center;
       user-select: none;
     }
@@ -136,13 +137,15 @@
     }
 
     .share,
-    .copy {
+    .copy,
+    .cancel {
       color: #00FFFF;
       cursor: pointer;
       text-decoration: underline;
     }
     .share .label,
-    .copy .label {
+    .copy .label,
+    .cancel .label {
       margin-left: 6px;
     }
 
@@ -222,6 +225,7 @@
       <DIV class="greeting">Hello, {teamName}!</DIV>
       <DIV>Your public game hasn't started yet.  It will start automatically once somebody joins your game.</DIV>
       <DIV class="shareLink"></DIV>
+      <DIV class="cancelButton"></DIV>
       <DIV>Tips:</DIV>
       <UL class="tips">
         <LI>If you get tired of waiting for an opponent, copy and/or share the above link with someone.</LI>
@@ -237,6 +241,7 @@
       <DIV class="greeting">Hello, {teamName}!</DIV>
       <DIV>Your private game will start automatically once an invited player joins your game.</DIV>
       <DIV class="shareLink"></DIV>
+      <DIV class="cancelButton"></DIV>
       <DIV>Tips:</DIV>
       <UL class="tips">
         <LI>Invite one or more people by copying and/or sharing the above link with them, e.g. by text or email.</LI>

--- a/static/online.html
+++ b/static/online.html
@@ -154,6 +154,7 @@
       font-weight: bold;
       margin: 8px 0 0;
     }
+
     .tabContent .game {
       display: flex;
       justify-content: space-between;
@@ -162,6 +163,7 @@
       padding: 8px;
       cursor: pointer;
     }
+
     .tabContent .game .left {
       flex: 1 1 auto;
       width: 18%;


### PR DESCRIPTION
Games can now be cancelled by user who created them.

Implementation notes:
Cancelling is realized by `deleted` flag. Games flagged as deleted are not propagated into `player_games` file and `open_games` file, therefore are not returned to be displayed.

CreatedBy property was added to `GameSummary`, so frontend can hide the delete button for users without the right to delete the game. 

Data migration is not handled - it won't be possible to cancel games which are already created (because CreatedBy attribute is missing from the summary). I don't think it matters too much and I'm also quite not sure how to do it properly.