### PR TITLE
Automatically cleanup open realtime games

### DIFF
--- a/src/data/FileAdapter.js
+++ b/src/data/FileAdapter.js
@@ -107,10 +107,10 @@ export default class {
     return game;
   }
 
-  async cancelGame(game) {
+  async cancelGame(gameId) {
 
-    return this._lock(`game_${game.id}`, 'write', async () => {
-      let gameRefreshed = await this._readFile(`game_${game.id}`, null);
+    return this._lock(`game_${gameId}`, 'write', async () => {
+      let gameRefreshed = await this._readFile(`game_${gameId}`, null);
       if (gameRefreshed === null) {
         return true;
       }
@@ -135,7 +135,7 @@ export default class {
         summaries.delete(gameRefreshed.id);
         return summaries;
       })
-      await this._deleteFile(`game_${game.id}`);
+      await this._deleteFile(`game_${gameRefreshed.id}`);
       return true;
     });
   }


### PR DESCRIPTION
Abandoned realtime games are cancelled after 15 minutes.

#### Notes / Concerns

- I've added the functionality to the `GameService` but I have a slight feeling this kind of behavior might warrant its own service in the future
- I don't like that games are searched for by explicit values instead of some predicate, this will break every time new possible limit is added. However, I wanted to avoid grabbing all the games and going through them manually. I think the `FileAdapter` should support predicate filtering.
