### PR TITLE
Fix fork of ended games

### DIFF
--- a/src/data/FileAdapter.js
+++ b/src/data/FileAdapter.js
@@ -114,6 +114,7 @@ export default class {
     let newGame = await this.getGame(newId);
     newGame.id = newId;
     newGame.isPublic = false;
+    newGame.state.turnTimeLimit = null;
     newGame.state.teams.forEach(team => {
       team.playerId = playerId;
     });

--- a/src/game-app.js
+++ b/src/game-app.js
@@ -1668,12 +1668,14 @@ function toggleReplayButtons() {
   let isSynced = game.isSynced;
   let atStart = isSynced || cursor.atStart;
   let atCurrent = isSynced || cursor.atCurrent;
+  let atEnd = isSynced || cursor.atEnd;
 
   $('BUTTON[name=start]').prop('disabled', atStart);
   $('BUTTON[name=back]').prop('disabled', atStart);
 
   $('BUTTON[name=forward]').prop('disabled', atCurrent);
   $('BUTTON[name=end]').prop('disabled', atCurrent);
+  $('BUTTON[name=fork]').prop('disabled', atEnd);
 }
 
 function setCursorAlert() {

--- a/src/server/GameService.js
+++ b/src/server/GameService.js
@@ -276,7 +276,16 @@ class GameService extends Service {
   async onForkGameRequest(client, gameId, turn) {
     this.debug(`forkGame: gameId=${gameId}`);
     let newGame = await dataAdapter.forkGame(gameId, this.clientPara.get(client.id).playerId);
-    newGame.state.revert(turn);
+    let turnToStartFrom = turn;
+    if (newGame.state.ended) {
+      newGame.state.winnerId = null;
+      newGame.state.ended = null;
+      // Don't include the winning turn, otherwise there's just one team left
+      if (turn === newGame.state._turns.length) {
+        turnToStartFrom = turn - 1 >= 0 ? turn - 1 : 0;
+      }
+    }
+    newGame.state.revert(turnToStartFrom);
     await dataAdapter.saveGame(newGame);
     return newGame.id;
   }


### PR DESCRIPTION
- Ended property is set to null
- Time limit is set to null
- Fork button is disabled when animation in progress or cursor is on the turn in which surrender occurs
- Added check preventing forking after the surrender turn on the server side