### PR TITLE
chore: dynamically generate game types on change to game_types.json

### DIFF
--- a/src/createGame.js
+++ b/src/createGame.js
@@ -1,5 +1,6 @@
 import Autosave from 'components/Autosave.js';
 import popup from 'components/popup.js';
+import gameTypeJSON from './data/files/game/game_types.json';
 
 const authClient = Tactics.authClient;
 const gameClient = Tactics.gameClient;
@@ -19,6 +20,15 @@ window.addEventListener('DOMContentLoaded', () => {
   }).on('submit', event => event.waitUntil(
     authClient.setAccountName(event.data),
   )).appendTo(divPlayerSetup);
+
+  // Dynamically generate gameType options in the createGame.html dropdown.
+  gameTypeJSON.forEach(gameType => {
+    const dropdownValue = gameType[0];
+    const dropdownText = gameType[1].name;
+
+    const dropdownOption = `<option value="${dropdownValue}">${dropdownText}</option>`
+    $('#gameTypes-dropdown').append(dropdownOption);
+  })
 
   let notice;
   if (navigator.onLine === false)

--- a/src/online.js
+++ b/src/online.js
@@ -9,6 +9,7 @@ import unitFactory from 'tactics/unitFactory.js';
 import Autosave from 'components/Autosave.js';
 import whenTransitionEnds from 'components/whenTransitionEnds.js';
 import LobbySettingsModal from 'components/Modal/LobbySettings.js';
+import gameTypeJSON from './data/files/game/game_types.json';
 
 // We will be fetching the updates games list from the server on this interval
 const GAMES_FETCH_INTERVAL = 5 * 1000;
@@ -18,20 +19,9 @@ const gameClient = Tactics.gameClient;
 const pushClient = Tactics.pushClient;
 const popup = Tactics.popup;
 
-const styles = new Map([
-  [ 'freestyle',        'Freestyle' ],
-  [ 'classic',          'Classic' ],
-  [ 'droplessGray',     'Dropless Gray' ],
-  [ 'fpsGray',          'FPS Gray' ],
-  [ 'legendsGray',      'Legends Gray' ],
-  [ 'alphaTurtle',      'Alpha Turtle' ],
-  [ 'legendsTurtle',    'Legends Turtle' ],
-  [ 'fpsGold',          'FPS Gold' ],
-  [ 'legendsGold',      'Legends Gold' ],
-  [ 'legendsGoldNoDSM', 'Legends Gold (no DSM)' ],
-  [ 'delta',            'Delta Force' ],
-  [ 'moderator',        'Moderator' ],
-]);
+// An array of gameTypes => [ [ 'freestyle, 'Freestyle' ], ['classic', 'Classic'], ['droplessGray', 'Dropless Gray'] ... ]
+const stylesArray = gameTypeJSON.map((gameType) => [gameType[0], gameType[1].name]);
+const styles = new Map(stylesArray);
 
 const groups = new Map([
   [ 'lobby',    'Lobby' ],

--- a/static/createGame.html
+++ b/static/createGame.html
@@ -106,19 +106,7 @@
       <DIV>
         <DIV>What game style do you want to play?</DIV>
         <DIV class="indent">
-          <SELECT name="type">
-            <OPTION value="classic">Classic</OPTION>
-            <OPTION value="droplessGray">Dropless Gray</OPTION>
-            <OPTION value="fpsGray">FPS Gray</OPTION>
-            <OPTION value="legendsGray">Legends Gray</OPTION>
-            <OPTION value="delta">Delta Force</OPTION>
-            <OPTION value="legendsTurtle">Legends Turtle</OPTION>
-            <OPTION value="alphaTurtle">Alpha Turtle</OPTION>
-            <OPTION value="legendsGold">Legends Gold</OPTION>
-            <OPTION value="legendsGoldNoDSM">Legends Gold (no DSM)</OPTION>
-            <OPTION value="fpsGold">FPS Gold</OPTION>
-            <OPTION value="freestyle">Freestyle</OPTION>
-            <OPTION value="moderator">Moderator</OPTION>
+          <SELECT name="type" id="gameTypes-dropdown">
           </SELECT>
           <A href="javascript:void(0)" class="change" style="display:none">Change Set</A>
         </DIV>


### PR DESCRIPTION
Changing a game type only requires changing of `game_types.json` and everything else will dynamically generate based on that file. Reference issue: 

<img width="790" alt="Screen Shot 2022-07-02 at 9 57 30 PM" src="https://user-images.githubusercontent.com/7416639/177021467-6c6f0f22-badc-4174-b85e-fbd918d16f4f.png">

Tested below locally on the following screens: 

<img width="502" alt="Screen Shot 2022-07-02 at 9 54 02 PM" src="https://user-images.githubusercontent.com/7416639/177021471-4a417e20-906e-49a4-95b4-fa6f67d148fc.png">
<img width="828" alt="Screen Shot 2022-07-02 at 9 54 25 PM" src="https://user-images.githubusercontent.com/7416639/177021472-af3d53d7-d807-4d90-bbec-85f8f99f7c7f.png">


