### PR TITLE
Fix bug with incorrect wait time when berserker attacks friendly unit

### DIFF
--- a/src/tactics/Unit/Berserker.js
+++ b/src/tactics/Unit/Berserker.js
@@ -7,9 +7,14 @@ export default class Berserker extends Unit {
   getAttackResult(action, unit, cUnit) {
     let result = super.getAttackResult(action, unit, cUnit);
 
-    if (!result.miss)
-      result.changes.mRecovery = result.unit.mRecovery + 1;
-
+    if (!result.miss) {
+      if (this.team !== result.unit.team) {
+        result.changes.mRecovery = result.unit.mRecovery + 1;
+      } else {
+        // If the berserker attacks an ally, increase wait by 2 to account for wait decrement at end of turn.
+        result.changes.mRecovery = result.unit.mRecovery + 2;
+      }
+    }
     return result;
   }
 }


### PR DESCRIPTION
Tested by playing game locally - (http://localhost:2000/)

1. Berserker attacked a friendly unit
3. Unit showed wait time of 2
4. Player ended turn
5. Unit showed wait time of 1

Also, attacked enemy unit and verified gain of only 1 wait.