### PR TITLE
Fix bug with incorrect wait time when berserker attacks friendly unit

### DIFF
--- a/src/tactics/GameState.js
+++ b/src/tactics/GameState.js
@@ -1299,8 +1299,14 @@ export default class GameState {
                 mRecovery = undefined;
             }
           }
-          else if (unit.mRecovery)
-            mRecovery = unit.mRecovery - 1;
+          else {
+            // Check recovery at the start of the turn, not the current recovery.
+            // This handles the case of a berserker attacking a friendly unit.
+            let unitAtTurnStart = this.units[unit.team.id].find(u => u.id === unit.id);
+            if (unitAtTurnStart.mRecovery) {
+              mRecovery = unit.mRecovery - 1;
+            }
+          }
 
           if (mRecovery !== undefined)
             result.changes.mRecovery = mRecovery;


### PR DESCRIPTION
Second fix for berserker after realizing there is a second bug for units that already have a recovery time.    

Testing

http://localhost:2000

**"Fixing the bug" test**
1. Attack friendly unit with berserker
2. Recovery changes to 1 
3. End turn - observe recovery stays at 1

**Regression tests**
1. Attack friendly unit with berserker which has a recovery time of 2
2. Recovery changes to 3
3. End turn - observe recovery falls to 2    
---
1. Attack enemy unit with berserker
2. Recovery changes to 1
3. End turn - recovery stays at 1 (for enemy unit)
5. End turn again - recovery falls to 0 (back to player's turn)    
---
1. Attack enemy unit with berserker which has a recovery time of 2
2. Recovery changes to 3
3. End turn - recovery stays at 3 (for enemy unit)
4. End turn again - recovery falls to 2 (back to player's turn)    
---
1. Heal with cleric 
2. Recovery of 3
3. End turn - recovery stays at 3
4. End turn - recovery stays at 3 (enemy turn)
7. End turn - recovery falls to 2     
---
