### PR TITLE
Fix bug where furgon shrub causes NPE when checking wait recovery

### DIFF
--- a/src/tactics/GameState.js
+++ b/src/tactics/GameState.js
@@ -1302,8 +1302,10 @@ export default class GameState {
           else {
             // Check recovery at the start of the turn, not the current recovery.
             // This handles the case of a berserker attacking a friendly unit.
+            // Note: this also needs an undefined check since the furgon's shrubs do not exist at turn start
+            //       and will be undefined
             let unitAtTurnStart = this.units[unit.team.id].find(u => u.id === unit.id);
-            if (unitAtTurnStart.mRecovery) {
+            if (!!unitAtTurnStart && unitAtTurnStart.mRecovery) {
               mRecovery = unit.mRecovery - 1;
             }
           }


### PR DESCRIPTION
The previous [pull request ](https://github.com/pongstylin/tactics/pull/120) actually introduced a bug which breaks the game when a furgon casts a shrub! This is due to the fact that we now check unit at start of turn to see if they are in recovery - but the furgon shrub did not exist at start of turn, which trickles down into an NPE when checking recovery time.   

Since the shrubs have no actual recovery, we can just skip past them on this check. Added simple null check.

Testing     
http://localhost:2000
1. Cast furgon shrub
2. Successfully end turn - previously the game froze at this step.