### PR TITLE
Prevent furgon from blocking when exhausted.

### DIFF
--- a/src/tactics/GameState.js
+++ b/src/tactics/GameState.js
@@ -1302,8 +1302,10 @@ export default class GameState {
           else {
             // Check recovery at the start of the turn, not the current recovery.
             // This handles the case of a berserker attacking a friendly unit.
+            // Note: this also needs an undefined check since the furgon's shrubs do not exist at turn start
+            //       and will be undefined
             let unitAtTurnStart = this.units[unit.team.id].find(u => u.id === unit.id);
-            if (unitAtTurnStart.mRecovery) {
+            if (!!unitAtTurnStart && unitAtTurnStart.mRecovery) {
               mRecovery = unit.mRecovery - 1;
             }
           }

--- a/src/tactics/Unit.js
+++ b/src/tactics/Unit.js
@@ -265,7 +265,7 @@ export default class Unit {
       // Armor reduces magic damage.
       calc.damage = Math.round(power * (100 - armor) / 100);
 
-      if (targetUnit.paralyzed || targetUnit.focusing)
+      if (targetUnit.paralyzed || targetUnit.focusing || !targetUnit.canBlock())
         calc.chance = 100;
       else if (targetUnit.directional === false) {
         // Wards have 100% blocking from all directions.
@@ -1882,6 +1882,9 @@ export default class Unit {
       !this.poisoned &&
       this.mPass !== false
     );
+  }
+  canBlock() {
+    return true;
   }
 
   clone() {

--- a/src/tactics/Unit/Furgon.js
+++ b/src/tactics/Unit/Furgon.js
@@ -66,6 +66,13 @@ export default class Furgon extends Unit {
       }]);
   }
 
+  /*
+   * Furgon cannot block when exhausted
+   */
+  canBlock() {
+    return this.disposition !== 'exhausted';
+  }
+
   getAttackTiles(start = this.assignment) {
     if (this.canSpecial())
       return [this.assignment];


### PR DESCRIPTION
Added new "canBlock" method to unit class. By default returns true - Furgon overrides it to false when it is exhausted.   

Testing    
1. Create exhausted furgon    
2. Verify furgon cannot block     
3. Skip turns until furgon is no longer exhausted - verify can now block
-----
1. Verify furgon that is not exhausted can block     
----
1. Verify knight can block