### PR TITLE
Add game types service

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,11 +18,19 @@ That is as far as it goes.  This project is intended to recreate the core game e
 
 ## Requirements
 * Node.js tested on version v16.16.0
+* Note: v18 does not work with current build.
 
 To install under windows, you also need Git Bash and configure npm to use the Git Bash executable.
 Example:
 ```bash
 npm config set script-shell "C:\\Program Files\\Git\\bin\\bash.exe"
+```
+
+To manage Node versions in windows consider using https://github.com/coreybutler/nvm-windows.
+Then 
+```
+nvm install v16.16.0
+nvm use v16.16.0
 ```
 
 ## Development

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tactics",
-  "version": "1.14.1",
+  "version": "1.14.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "tactics",
-      "version": "1.14.1",
+      "version": "1.14.4",
       "license": "Unlicense",
       "dependencies": {
         "@pixi/canvas-display": "^6.5.5",

--- a/src/client/GameClient.js
+++ b/src/client/GameClient.js
@@ -81,6 +81,14 @@ export default class GameClient extends Client {
   /*
    * Authorization not required for these read operations
    */
+  getGameTypes() {
+    return this._server.request(this.name, 'getGameTypes')
+      .catch(error => {
+        if (error === 'Connection reset')
+          return this.getGameTypes();
+        throw error;
+      });
+  }
   getGameType(gameTypeId) {
     return this._server.request(this.name, 'getGameTypeConfig', [gameTypeId])
       .catch(error => {

--- a/src/createGame.js
+++ b/src/createGame.js
@@ -48,7 +48,7 @@ window.addEventListener('DOMContentLoaded', () => {
 
   const gameTypes = gameClient.getGameTypes().then((gameTypes) => {
     const gameTypesHTML = gameTypes.map((gameType) => {
-      return `<OPTION value="${gameType[0]}">${gameType[1]}</OPTION>`
+      return `<OPTION value="${gameType.id}">${gameType.name}</OPTION>`
     })
     const selGameType = document.querySelector('SELECT[name=type]')
     selGameType.innerHTML = gameTypesHTML.join('')

--- a/src/createGame.js
+++ b/src/createGame.js
@@ -46,6 +46,14 @@ window.addEventListener('DOMContentLoaded', () => {
     divConfigure.classList.add('show');
   });
 
+  const gameTypes = gameClient.getGameTypes().then((gameTypes) => {
+    const gameTypesHTML = gameTypes.map((gameType) => {
+      return `<OPTION value="${gameType[0]}">${gameType[1]}</OPTION>`
+    })
+    const selGameType = document.querySelector('SELECT[name=type]')
+    selGameType.innerHTML = gameTypesHTML.join('')
+  });
+
   const selGameType = document.querySelector('SELECT[name=type]');
   const selSet = document.querySelector('SELECT[name=set]');
   const aChangeLink = document.querySelector('.change');

--- a/src/data/FileAdapter/GameAdapter.js
+++ b/src/data/FileAdapter/GameAdapter.js
@@ -175,10 +175,10 @@ export default class extends FileAdapter {
   }
   getGameTypes() {
     return [...this._gameTypes.values()]
-      .map(({ id, config }) => ([
-        id, 
-        config.name,
-      ]));
+      .map(({ id, config }) => ({
+        id: id, 
+        name: config.name,
+    }));
   }
   getGameType(gameTypeId) {
     const gameTypes = this._gameTypes;

--- a/src/data/FileAdapter/GameAdapter.js
+++ b/src/data/FileAdapter/GameAdapter.js
@@ -173,6 +173,13 @@ export default class extends FileAdapter {
   hasGameType(gameTypeId) {
     return this._gameTypes.has(gameTypeId);
   }
+  getGameTypes() {
+    return [...this._gameTypes.values()]
+      .map(({ id, config }) => ([
+        id, 
+        config.name,
+      ]));
+  }
   getGameType(gameTypeId) {
     const gameTypes = this._gameTypes;
     if (!gameTypes.has(gameTypeId))

--- a/src/data/files/game/game_types.json
+++ b/src/data/files/game/game_types.json
@@ -1,4 +1,79 @@
 [
+    [
+    "freestyle",
+    {
+      "name": "Freestyle",
+      "description": "This style lets you use all the units you could buy including the extra copies (drops) you could earn on the original game commercial site (FPS) without restriction.",
+      "customizable": true,
+      "limits": {
+        "tiles": { "start":[0,0], "end":[10,4] },
+        "points": 10,
+        "units": {
+          "types": [
+            ["Scout",             { "max":2  }],
+            ["Assassin",          { "max":10 }],
+            ["Knight",            { "max":3  }],
+            ["Cleric",            { "max":10 }],
+            ["StoneGolem",        { "max":1  }],
+            ["Pyromancer",        { "max":10 }],
+            ["Enchantress",       { "max":10 }],
+            ["DarkMagicWitch",    { "max":10 }],
+            ["BarrierWard",       { "max":9  }],
+            ["LightningWard",     { "max":1  }],
+            ["MudGolem",          { "max":10 }],
+            ["PoisonWisp",        { "max":1  }],
+            ["FrostGolem",        { "max":10 }],
+            ["DragonTyrant",      { "max":1, "points":2 }],
+            ["Furgon",            { "max":1  }],
+            ["DragonspeakerMage", { "max":1  }],
+            ["BeastRider",        { "max":10 }],
+            ["GolemAmbusher",     { "max":1  }],
+            ["Berserker",         { "max":1  }]
+          ]
+        }
+      },
+      "sets": [{
+        "name": "AFO Rush",
+        "units": [
+          { "assignment":[5, 0], "type":"Cleric" },
+          { "assignment":[5, 2], "type":"DragonTyrant", "mPower":-12 },
+          { "assignment":[1, 4], "type":"Scout" },
+          { "assignment":[2, 4], "type":"Knight" },
+          { "assignment":[4, 4], "type":"MudGolem" },
+          { "assignment":[5, 4], "type":"Knight" },
+          { "assignment":[6, 4], "type":"DragonspeakerMage", "mPower":12 },
+          { "assignment":[8, 4], "type":"Knight" },
+          { "assignment":[9, 4], "type":"Scout" }
+        ]
+      },{
+        "name": "Standard Anti",
+        "units":[
+          {"type":"Scout","assignment":[10,4]},
+          {"type":"Knight","assignment":[9,4]},
+          {"type":"MudGolem","assignment":[8,4]},
+          {"type":"DragonTyrant","assignment":[7,4]},
+          {"type":"Knight","assignment":[6,4]},
+          {"type":"Knight","assignment":[5,3]},
+          {"type":"FrostGolem","assignment":[8,1]},
+          {"type":"Cleric","assignment":[8,0]},
+          {"type":"Scout","assignment":[6,1]}
+        ]
+      },{
+        "name": "Double D",
+        "units": [
+          {"type":"Cleric","assignment":[8,0]},
+          {"type":"Knight","assignment":[8,1]},
+          {"type":"Scout","assignment":[1,4]},
+          {"type":"MudGolem","assignment":[3,4]},
+          {"type":"PoisonWisp","assignment":[4,4]},
+          {"type":"Scout","assignment":[6,4]},
+          {"type":"DragonspeakerMage","assignment":[7,4]},
+          {"type":"Knight","assignment":[8,4]},
+          {"type":"DragonTyrant","assignment":[10,4]}
+        ]
+      }]
+    }
+  ],
   [
     "classic",
     {
@@ -546,81 +621,6 @@
           { "assignment":[6, 4], "type":"DragonspeakerMage", "mPower":12 },
           { "assignment":[8, 4], "type":"Knight" },
           { "assignment":[9, 4], "type":"Scout" }
-        ]
-      }]
-    }
-  ],
-  [
-    "freestyle",
-    {
-      "name": "Freestyle",
-      "description": "This style lets you use all the units you could buy including the extra copies (drops) you could earn on the original game commercial site (FPS) without restriction.",
-      "customizable": true,
-      "limits": {
-        "tiles": { "start":[0,0], "end":[10,4] },
-        "points": 10,
-        "units": {
-          "types": [
-            ["Scout",             { "max":2  }],
-            ["Assassin",          { "max":10 }],
-            ["Knight",            { "max":3  }],
-            ["Cleric",            { "max":10 }],
-            ["StoneGolem",        { "max":1  }],
-            ["Pyromancer",        { "max":10 }],
-            ["Enchantress",       { "max":10 }],
-            ["DarkMagicWitch",    { "max":10 }],
-            ["BarrierWard",       { "max":9  }],
-            ["LightningWard",     { "max":1  }],
-            ["MudGolem",          { "max":10 }],
-            ["PoisonWisp",        { "max":1  }],
-            ["FrostGolem",        { "max":10 }],
-            ["DragonTyrant",      { "max":1, "points":2 }],
-            ["Furgon",            { "max":1  }],
-            ["DragonspeakerMage", { "max":1  }],
-            ["BeastRider",        { "max":10 }],
-            ["GolemAmbusher",     { "max":1  }],
-            ["Berserker",         { "max":1  }]
-          ]
-        }
-      },
-      "sets": [{
-        "name": "AFO Rush",
-        "units": [
-          { "assignment":[5, 0], "type":"Cleric" },
-          { "assignment":[5, 2], "type":"DragonTyrant", "mPower":-12 },
-          { "assignment":[1, 4], "type":"Scout" },
-          { "assignment":[2, 4], "type":"Knight" },
-          { "assignment":[4, 4], "type":"MudGolem" },
-          { "assignment":[5, 4], "type":"Knight" },
-          { "assignment":[6, 4], "type":"DragonspeakerMage", "mPower":12 },
-          { "assignment":[8, 4], "type":"Knight" },
-          { "assignment":[9, 4], "type":"Scout" }
-        ]
-      },{
-        "name": "Standard Anti",
-        "units":[
-          {"type":"Scout","assignment":[10,4]},
-          {"type":"Knight","assignment":[9,4]},
-          {"type":"MudGolem","assignment":[8,4]},
-          {"type":"DragonTyrant","assignment":[7,4]},
-          {"type":"Knight","assignment":[6,4]},
-          {"type":"Knight","assignment":[5,3]},
-          {"type":"FrostGolem","assignment":[8,1]},
-          {"type":"Cleric","assignment":[8,0]},
-          {"type":"Scout","assignment":[6,1]}
-        ]
-      },{
-        "name": "Double D",
-        "units": [
-          {"type":"Cleric","assignment":[8,0]},
-          {"type":"Knight","assignment":[8,1]},
-          {"type":"Scout","assignment":[1,4]},
-          {"type":"MudGolem","assignment":[3,4]},
-          {"type":"PoisonWisp","assignment":[4,4]},
-          {"type":"Scout","assignment":[6,4]},
-          {"type":"DragonspeakerMage","assignment":[7,4]},
-          {"type":"Knight","assignment":[8,4]},
-          {"type":"DragonTyrant","assignment":[10,4]}
         ]
       }]
     }

--- a/src/online.js
+++ b/src/online.js
@@ -21,21 +21,6 @@ const gameClient = Tactics.gameClient;
 const pushClient = Tactics.pushClient;
 const popup = Tactics.popup;
 
-const styles = new Map([
-  [ 'freestyle',        'Freestyle' ],
-  [ 'classic',          'Classic' ],
-  [ 'droplessGray',     'Dropless Gray' ],
-  [ 'fpsGray',          'FPS Gray' ],
-  [ 'legendsGray',      'Legends Gray' ],
-  [ 'alphaTurtle',      'Alpha Turtle' ],
-  [ 'legendsTurtle',    'Legends Turtle' ],
-  [ 'fpsGold',          'FPS Gold' ],
-  [ 'legendsGold',      'Legends Gold' ],
-  [ 'legendsGoldNoDSM', 'Legends Gold (no DSM)' ],
-  [ 'delta',            'Delta Force' ],
-  [ 'moderator',        'Moderator' ],
-]);
-
 const groups = new Map([
   [ 'lobby',    'Lobby' ],
   [ 'active',   'Active Games' ],
@@ -95,6 +80,7 @@ const state = {
       selectedStyleId: null,
       selectedGroupId: 'lobby',
       sets: null,
+      styles: null,
     },
     publicGames: {
       isOpen: false,
@@ -143,9 +129,13 @@ const pushPublicKey = Uint8Array.from(
   chr => chr.charCodeAt(0),
 );
 
+const setGameTypesState = (gameTypes) => {
+   state.tabContent.lobby.styles = new Map(gameTypes);
+}
+
 let avatars;
 let arena;
-const avatarsPromise = Tactics.load([ 'avatars' ]).then(async () => {
+const handleAvatarsData = async () => {
   avatars = Tactics.getSprite('avatars');
   arena = avatars.getImage('arena');
   ScrollButton.config.icons = {
@@ -156,9 +146,19 @@ const avatarsPromise = Tactics.load([ 'avatars' ]).then(async () => {
     hover: avatars.getSound('focus').howl,
     click: avatars.getSound('select').howl,
   };
+}
 
-  await whenDOMReady;
-  renderLobby();
+const dataServices = [
+  gameClient.getGameTypes(),
+  Tactics.load(['avatars'])
+]
+
+const getDataFromService = () => Promise.all(dataServices)
+  .then(async ([gameTypesData, avatarsData]) => {
+    setGameTypesState(gameTypesData);
+    await handleAvatarsData();
+    await whenDOMReady;
+    renderLobby();
 });
 
 const getAvatar = (playerId, direction) => {
@@ -403,11 +403,11 @@ async function showTabs() {
   myPlayerId = authClient.playerId;
   setMyName();
 
-  const avatar = (await gameClient.getPlayersAvatar([ myPlayerId ]))[0];
+  const avatar = (await gameClient.getPlayersAvatar([ myPlayerId ]))[0]; 
 
   document.body.classList.toggle('account-is-at-risk', isAccountAtRisk);
 
-  await avatarsPromise;
+  await getDataFromService();
   setMyAvatar(avatar);
   state.tabContent.lobby.setup.avatar = avatar;
 
@@ -663,6 +663,7 @@ function selectStyle(styleId) {
     ulFloorList.querySelector(`[data-style-id=${tabContent.selectedStyleId}]`).classList.remove('selected');
   ulFloorList.querySelector(`[data-style-id=${styleId}]`).classList.add('selected');
 
+  const styles = state.tabContent.lobby.styles;
   spnStyle.textContent = styles.get(styleId);
   tabContent.selectedStyleId = styleId;
 }
@@ -1254,6 +1255,8 @@ function renderFloors() {
   divFloors.appendChild(divFloorList);
 
   const ulFloorList = document.createElement('UL');
+
+  const styles = state.tabContent.lobby.styles;
   for (const [ styleId, styleName ] of styles) {
     const liFloor = document.createElement('LI');
     liFloor.dataset.styleId = styleId;

--- a/src/online.js
+++ b/src/online.js
@@ -130,7 +130,7 @@ const pushPublicKey = Uint8Array.from(
 );
 
 const setGameTypesState = (gameTypes) => {
-   state.tabContent.lobby.styles = new Map(gameTypes);
+   state.tabContent.lobby.styles = gameTypes;
 }
 
 let avatars;
@@ -148,13 +148,9 @@ const handleAvatarsData = async () => {
   };
 }
 
-const dataServices = [
-  gameClient.getGameTypes(),
-  Tactics.load(['avatars'])
-]
-
-const getDataFromService = () => Promise.all(dataServices)
-  .then(async ([gameTypesData, avatarsData]) => {
+const getDataFromService = Tactics.load(['avatars'])
+  .then(async () => {
+    const gameTypesData = await gameClient.getGameTypes()
     setGameTypesState(gameTypesData);
     await handleAvatarsData();
     await whenDOMReady;
@@ -407,7 +403,7 @@ async function showTabs() {
 
   document.body.classList.toggle('account-is-at-risk', isAccountAtRisk);
 
-  await getDataFromService();
+  await getDataFromService;
   setMyAvatar(avatar);
   state.tabContent.lobby.setup.avatar = avatar;
 
@@ -664,7 +660,7 @@ function selectStyle(styleId) {
   ulFloorList.querySelector(`[data-style-id=${styleId}]`).classList.add('selected');
 
   const styles = state.tabContent.lobby.styles;
-  spnStyle.textContent = styles.get(styleId);
+  spnStyle.textContent = styles.find(style => style.id === styleId).name;
   tabContent.selectedStyleId = styleId;
 }
 async function selectGroup(groupId) {
@@ -1257,7 +1253,7 @@ function renderFloors() {
   const ulFloorList = document.createElement('UL');
 
   const styles = state.tabContent.lobby.styles;
-  for (const [ styleId, styleName ] of styles) {
+  for (const { id: styleId, name: styleName } of styles) {
     const liFloor = document.createElement('LI');
     liFloor.dataset.styleId = styleId;
     liFloor.addEventListener('mouseenter', () => {

--- a/src/server/GameService.js
+++ b/src/server/GameService.js
@@ -57,6 +57,7 @@ export default class GameService extends Service {
         cancelGame: [ 'uuid' ],
         joinGame: `tuple([ 'uuid', 'game:joinTeam' ], 1)`,
 
+        getGameTypes: [],
         getGameTypeConfig: [ 'string' ],
         getGame: [ 'uuid' ],
         getTurnData: [ 'uuid', 'integer(0)' ],
@@ -201,6 +202,7 @@ export default class GameService extends Service {
     if (body.method === 'getTurnData') return true;
     if (body.method === 'getTurnActions') return true;
     if (body.method === 'getGameTypeConfig') return true;
+    if (body.method === 'getGameTypes') return true;
 
     // Authorization required
     const clientPara = this.clientPara.get(client.id);
@@ -615,6 +617,10 @@ export default class GameService extends Service {
     }
 
     game.cancel();
+  }
+
+  async onGetGameTypesRequest(client) {
+    return this.data.getGameTypes();
   }
 
   async onGetGameTypeConfigRequest(client, gameTypeId) {


### PR DESCRIPTION
See #101 
Adds the getGameType service to the GameClient, and the needed backend funcs to handle the request.

Two things:
1: Obviously, any feed back on code style/functionality you would like addressed I can make happen.
2: This change is not ready to actually merge.  There is a bug that this change introduces, and it is not clear to me what the intent of how the DOM renders is.  

All code referenced below can be found in `online.js`

Reproduce the bug: 
1. Run locally
2. Open two browsers and go to the lobby.
3. Refresh the two browser pages and check the lobby of the other browser.
-- You should see that the `renderLobby() `function is re-running every time you refresh one of the browsers and causing a duplicate of the lobby to show up on the other browser.
You can see this happening all the way back at the `showTabs()` function.
Even in the current master branch, you can observe` showTabs() `rerunning every time you do the above steps.

Essentially:
It's not clear if running `showTabs()` like this is intended functionality, and that I need to handle my Promises to stop `renderLobby()` from rendering if it is already rendered
Or, if this behavior in `showTabs()` is not desired, and instead we should prevent any of this stuff from rerendering if it already is rendered.