### PR TITLE
Double click heal on Cleric

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tactics",
-  "version": "1.15.12",
+  "version": "1.15.15",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tactics",
-      "version": "1.15.12",
+      "version": "1.15.15",
       "license": "Unlicense",
       "dependencies": {
         "@pixi/canvas-display": "^6.5.10",


### PR DESCRIPTION
Main object: Add in cleric double click to heal. Impact: Time saving for the user, feature in original game.

Steps for user:
1. Click Attack Mode First
2. Click Cleric
3. [New Behavior] Allow for clicking cleric on itself to initiate heal

Approach: Add self to target units list

Testing edge cases:
* By default when when adding self, it will heal self as well, generating 12 white text over the cleric
  * Fix: remove self from `getAttackResults calc` list
* When self is damaged, it will double heal self because it will add self by default and also add from damage 
  * Fix: Remove self from initial `getTargetsUnits` call, and always add self

Video showing both fixed edge cases:
https://www.loom.com/share/064ad3914f234ff4a2bae0822d3b5b9e