### PR TITLE
aAll self target, cleric double click heal

### DIFF
--- a/src/tactics/Unit.js
+++ b/src/tactics/Unit.js
@@ -92,7 +92,7 @@ export default class Unit {
     if (this.aLOS === true)
       return this.getLOSTargetTiles(target, source);
     else if (this.aAll === true)
-      return this.getAttackTiles(source);
+      return [...this.getAttackTiles(source), this.assignment];
     else if (this.aLinear === true) {
       let direction = this.board.getDirection(source, target);
       let targets = [];

--- a/src/tactics/Unit/Cleric.js
+++ b/src/tactics/Unit/Cleric.js
@@ -5,7 +5,7 @@ export default class Cleric extends Unit {
     return this.getTargetUnits().map(u => u.assignment);
   }
   getTargetTiles() {
-    return this.getAttackTiles();
+    return [...this.getAttackTiles(), this.assignment];
   }
   getTargetUnits() {
     return this.team.units.filter(u => u.mHealth < 0);


### PR DESCRIPTION
Main object: Add in cleric double click to heal. Impact: Time saving for the user, feature in original game.

Steps for user:

* Click Attack Mode First
* Click Cleric
* [New Behavior] Allow for clicking cleric on itself to initiate heal

Approach: Add self to target units list

Cases Tested:
* Regular units without aAll or not cleric will not have its own space to target
* Cleric will not heal self when full HP
* Cleric will not double heal self when missing HP
* Cleric will heal only self if only self is damaged
* Assassin, enchantress and wisp can self-target for attack

Demo:
https://www.loom.com/share/554be7a6a8314b0b901e2b6d7d75e6d9