### PR TITLE
Double self-click for attack on aAll units

### DIFF
--- a/src/tactics/Board.js
+++ b/src/tactics/Board.js
@@ -1623,7 +1623,7 @@ export default class Board {
 
   showTargets(target) {
     let selected = this.selected;
-    let targeted = this.targeted = new Set(selected.getTargetUnits(target));
+    let targeted = this.targeted = new Set(selected.getTargetUnitsWithoutSelf(target));
 
     // Units affected by the attack will pulsate.
     targeted.forEach(tu => {
@@ -1923,6 +1923,7 @@ export default class Board {
 
     let unit = tile.assigned;
     let game = Tactics.game;
+    const selected = this.selected;
 
     // Single-click attacks are only enabled for mouse pointers.
     if (tile.action === 'attack') {
@@ -1932,7 +1933,11 @@ export default class Board {
     else if (tile.action === 'target') {
       if (game.pointerType === 'mouse')
         this._clearTargetMix(tile);
-      if (unit)
+      if (selected?.aAll) {
+        // Don't unset notice for aAll targets, or it will display defaults
+        const target = selected.getTargetUnitsWithoutSelf(selected)[0];
+        selected.setTargetNotice(target);
+      } else if (unit)
         unit.change({ notice:null });
     }
 

--- a/src/tactics/Game.js
+++ b/src/tactics/Game.js
@@ -790,7 +790,6 @@ export default class Game {
       height  = vpHeight;
       height -= rect.top;
       //height -= vpHeight - rect.bottom;
-      //console.log(vpHeight, rect.bottom);
     }
     else
       height -= canvas.offsetTop;

--- a/src/tactics/Unit.js
+++ b/src/tactics/Unit.js
@@ -170,7 +170,7 @@ export default class Unit {
   getTargetUnitsWithoutSelf(target) {
     const targetUnits = this.getTargetUnits(target);
 
-    if (this.aAll && this.name !== 'Cleric') // Click should heal self
+    if (this.aAll && this.type !== 'Cleric') // Cleric should be able to heal self
       return targetUnits.filter(unit => unit !== this);
     return targetUnits;
   }
@@ -1678,8 +1678,10 @@ export default class Unit {
       `${Math.min(99, Math.max(1, Math.round(calc.chance)))}%`;
     let notice;
 
-    if (this.aAll && targetUnit === this)
-      notice = ''; // aAll self taretting shouldn't show damage on self
+    if (this.type === 'Cleric' && targetUnit.mHealth === 0
+      || this.aAll && targetUnit === this && this.type !== 'Cleric')
+      // aAll shouldn't show damage on self or empty heal
+      notice = '';
     else if (calc.effect)
       notice = calc.effect.toUpperCase('first')+'!';
     else if (calc.miss === 'immune')

--- a/src/tactics/Unit/Cleric.js
+++ b/src/tactics/Unit/Cleric.js
@@ -5,7 +5,7 @@ export default class Cleric extends Unit {
     return this.getTargetUnits().map(u => u.assignment);
   }
   getTargetTiles() {
-    return this.getAttackTiles();
+    return [...this.getAttackTiles(), this.assignment];
   }
   getTargetUnits() {
     return this.team.units.filter(u => u.mHealth < 0);


### PR DESCRIPTION
Main objective: Add in double click on cleric, assassin, poison wisp and enchantress to cast attack / heal.
Impact: Time saving for the user, feature in original game.

Steps for user:

* Click Attack Mode First
* Click `aAll` unit (cleric, asssassin, poison wisp, enchantress)
* [New Behavior] Allow for clicking cleric on itself to initiate heal

Approach: Add self to target tiles list in `getTargetTiles`

Cases Tested:
* NEW: `aAll` units will not attack self
* NEW: `aAll` Units will show affected target on card by default or when blurred
* NEW: `aAll` Units will not show self damage on the card when focused or blurred
* NEW: Cleric will not show self hit notice when full HP
* Regular units without aAll will not have their own tile highlighted by default
* Cleric will not heal self when full HP
* Cleric will not double heal self when missing HP
* Cleric will heal only self if only self is damaged
* Assassin, enchantress and wisp can self-target for attack surrounding targets

Demo: