### PR TITLE
aAll units self-click, cleric heal

### DIFF
--- a/src/tactics/Board.js
+++ b/src/tactics/Board.js
@@ -1632,8 +1632,9 @@ export default class Board {
       selected.setTargetNotice(tu, target);
     });
 
-    // If only one unit is affected, draw card.
-    if (targeted.size === 1)
+    // Draw card if only one unit is affected, or aAll
+    // If aAll not handled, with multiple targets, it will show self
+    if (targeted.size === 1 || selected?.aAll && targeted.size > 0)
       // Pass the targeted unit to override the focused unit, if any.
       this.drawCard([...this.targeted][0]);
 

--- a/src/tactics/Game.js
+++ b/src/tactics/Game.js
@@ -790,7 +790,6 @@ export default class Game {
       height  = vpHeight;
       height -= rect.top;
       //height -= vpHeight - rect.bottom;
-      //console.log(vpHeight, rect.bottom);
     }
     else
       height -= canvas.offsetTop;

--- a/src/tactics/Unit.js
+++ b/src/tactics/Unit.js
@@ -92,7 +92,7 @@ export default class Unit {
     if (this.aLOS === true)
       return this.getLOSTargetTiles(target, source);
     else if (this.aAll === true)
-      return this.getAttackTiles(source);
+      return [...this.getAttackTiles(source), this.assignment];
     else if (this.aLinear === true) {
       let direction = this.board.getDirection(source, target);
       let targets = [];
@@ -149,6 +149,11 @@ export default class Unit {
       let unit = this.getLOSTargetUnit(target);
       if (unit)
         target_units.push(unit);
+    }
+    else if (this.aAll === true) {
+      target_units = this.getAttackTiles()
+        .filter(tile => !!tile.assigned)
+        .map(tile => tile.assigned);
     }
     else
       target_units = this.getTargetTiles(target)
@@ -1318,6 +1323,9 @@ export default class Unit {
       if (targetUnit)
         targets.push(targetUnit.assignment);
     }
+    else if (this.aAll === true)
+      // For aAll use attack tiles or it will animate self attack
+      targets = this.getAttackTiles();
     else
       targets = this.getTargetTiles(action.target);
 
@@ -1664,7 +1672,11 @@ export default class Unit {
       `${Math.min(99, Math.max(1, Math.round(calc.chance)))}%`;
     let notice;
 
-    if (calc.effect)
+    if (this.type === 'Cleric' && targetUnit.mHealth === 0
+      || this.aAll && targetUnit === this && this.type !== 'Cleric')
+      // aAll shouldn't show damage on self or empty heal
+      notice = '';
+    else if (calc.effect)
       notice = calc.effect.toUpperCase('first')+'!';
     else if (calc.miss === 'immune')
       notice = 'Immune!';

--- a/src/tactics/Unit/Cleric.js
+++ b/src/tactics/Unit/Cleric.js
@@ -5,7 +5,7 @@ export default class Cleric extends Unit {
     return this.getTargetUnits().map(u => u.assignment);
   }
   getTargetTiles() {
-    return this.getAttackTiles();
+    return [...this.getAttackTiles(), this.assignment];
   }
   getTargetUnits() {
     return this.team.units.filter(u => u.mHealth < 0);


### PR DESCRIPTION
Main objective: Add in double click on cleric, assassin, poison wisp and enchantress to cast attack / heal.
Impact: Time saving for the user, feature in original game.

Steps for user:

* Click Attack Mode First
* Click `aAll` unit (cleric, asssassin, poison wisp, enchantress)
* [New Behavior] Allow for clicking cleric on itself to initiate heal

Approach: Add self to target tiles list in `getTargetTiles`, modify existing calls to `getTargetUnits` to use `getAttackTiles` instead to ensure we are not targeting the unit itself.

Cases Tested:
* NEW: Tested on non-quick mode with incognito
* NEW: `aAll` units will not attack self
* NEW: `aAll` Units will show affected target on card by default or when blurred
* NEW: `aAll` Units will not show self damage on the card when focused or blurred
* NEW: Cleric will not show self hit notice when full HP
* Regular units without aAll will not have their own tile highlighted by default
* Cleric will not heal self when full HP
* Cleric will not double heal self when missing HP
* Cleric will heal only self if only self is damaged
* Assassin, enchantress and wisp can self-target for attack surrounding targets

Demo:
https://www.loom.com/share/e8ba68d94dbb46f780b4c8c8be0a3a4b