### PR TITLE
Open replay at turn 1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tactics",
-  "version": "1.17.0",
+  "version": "1.17.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tactics",
-      "version": "1.17.0",
+      "version": "1.17.1",
       "license": "Unlicense",
       "dependencies": {
         "@pixi/canvas-display": "^6.5.10",

--- a/src/online.js
+++ b/src/online.js
@@ -299,11 +299,13 @@ whenDOMReady.then(() => {
       return;
     }
 
+    const replayLink = link + "#c=1,0";
+
     // Support common open-new-tab semantics
     if (event.ctrlKey || event.metaKey || event.button === 1)
-      open(link, '_blank');
+      open(replayLink, '_blank');
     else
-      location.href = link;
+      location.href = replayLink;
   };
   document.querySelector('.tabContent').addEventListener('mouseup', event => {
     // Detect and handle middle-click
@@ -395,7 +397,7 @@ async function showTabs() {
   myPlayerId = authClient.playerId;
   setMyName();
 
-  const avatar = (await gameClient.getPlayersAvatar([ myPlayerId ]))[0]; 
+  const avatar = (await gameClient.getPlayersAvatar([ myPlayerId ]))[0];
 
   document.body.classList.toggle('account-is-at-risk', isAccountAtRisk);
 
@@ -2433,4 +2435,3 @@ async function fetchGames(tabName) {
     return fetchGames(tabName);
   });
 }
-


### PR DESCRIPTION
Goal: when opening replay from `Public Games`, have replay start from the beginning not from the end.

Testing indicates commit works for replays in `Your Games`. Not sure how to get any games to `Public Games`.

Not sure what package-lock.json is about and if it needs to be in commit.